### PR TITLE
add missing #include <string.h>

### DIFF
--- a/src/sail-codecs/png/png.c
+++ b/src/sail-codecs/png/png.c
@@ -26,6 +26,7 @@
 #include <setjmp.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <string.h>
 
 #include <png.h>
 


### PR DESCRIPTION
```sh
[ 27%] Building C object src/sail-codecs/png/CMakeFiles/sail-codec-png.dir/png.c.o
/usr/src/libs/graphics/sail/jopadan/sail/src/sail-codecs/png/png.c: In function ‘sail_codec_load_frame_v8_png’:
/usr/src/libs/graphics/sail/jopadan/sail/src/sail-codecs/png/png.c:453:17: error: implicit declaration of function ‘memcpy’ [-Wimplicit-function-declaration]
  453 |                 memcpy(scanline, png_state->prev[row], png_state->first_image->bytes_per_line);
      |                 ^~~~~~
/usr/src/libs/graphics/sail/jopadan/sail/src/sail-codecs/png/png.c:36:1: note: include ‘<string.h>’ or provide a declaration of ‘memcpy’
   35 | #include "io.h"
  +++ |+#include <string.h>
   36 | 
/usr/src/libs/graphics/sail/jopadan/sail/src/sail-codecs/png/png.c:453:17: warning: incompatible implicit declaration of built-in function ‘memcpy’ [-Wbuiltin-declaration-mismatch]
  453 |                 memcpy(scanline, png_state->prev[row], png_state->first_image->bytes_per_line);
      |                 ^~~~~~
/usr/src/libs/graphics/sail/jopadan/sail/src/sail-codecs/png/png.c:453:17: note: include ‘<string.h>’ or provide a declaration of ‘memcpy’
/usr/src/libs/graphics/sail/jopadan/sail/src/sail-codecs/png/png.c:479:29: error: implicit declaration of function ‘memset’ [-Wimplicit-function-declaration]
  479 |                             memset(png_state->prev[row] + png_state->next_frame_x_offset * png_state->bytes_per_pixel,
      |                             ^~~~~~
/usr/src/libs/graphics/sail/jopadan/sail/src/sail-codecs/png/png.c:479:29: note: include ‘<string.h>’ or provide a declaration of ‘memset’
/usr/src/libs/graphics/sail/jopadan/sail/src/sail-codecs/png/png.c:479:29: warning: incompatible implicit declaration of built-in function ‘memset’ [-Wbuiltin-declaration-mismatch]
/usr/src/libs/graphics/sail/jopadan/sail/src/sail-codecs/png/png.c:479:29: note: include ‘<string.h>’ or provide a declaration of ‘memset’
make[2]: *** [src/sail-codecs/png/CMakeFiles/sail-codec-png.dir/build.make:107: src/sail-codecs/png/CMakeFiles/sail-codec-png.dir/png.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:2527: src/sail-codecs/png/CMakeFiles/sail-codec-png.dir/all] Error 2

```