### PR TITLE
Potential fix for code scanning alert no. 199: Multiplication result converted to larger type

### DIFF
--- a/tests/sail-manip/rotate.c
+++ b/tests/sail-manip/rotate.c
@@ -46,7 +46,7 @@ static sail_status_t create_test_image(unsigned width,
     image->bytes_per_line = sail_bytes_per_line(width, pixel_format);
 
     /* Allocate pixels */
-    const size_t pixels_size = image->height * image->bytes_per_line;
+    const size_t pixels_size = (size_t)image->height * image->bytes_per_line;
     SAIL_TRY(sail_malloc(pixels_size, &image->pixels));
 
     /* Fill with a simple pattern: each pixel value is row * width + col */


### PR DESCRIPTION
Potential fix for [https://github.com/HappySeaFox/sail/security/code-scanning/199](https://github.com/HappySeaFox/sail/security/code-scanning/199)

To fix this issue, ensure that the multiplication takes place in the wider type (`size_t`) rather than the default type (`unsigned int`). This can be achieved by casting one (or both) operands to `size_t` before performing the multiplication. Specifically, in `pixels_size = image->height * image->bytes_per_line;`, cast `image->height` to `size_t`: `pixels_size = (size_t)image->height * image->bytes_per_line;`. Make this change in the relevant line in the `create_test_image` function in `tests/sail-manip/rotate.c`.

No additional methods, imports, or global definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
