### PR TITLE
HDR: Switch pixel format to more specific BPP96_RGB_FLOAT

### DIFF
--- a/src/sail-codecs/hdr/hdr.c
+++ b/src/sail-codecs/hdr/hdr.c
@@ -141,7 +141,7 @@ SAIL_EXPORT sail_status_t sail_codec_load_seek_next_frame_v8_hdr(void* state, st
     image_local->height = hdr_state->header.height;
 
     /* HDR uses 32-bit float RGB (96 bits total). */
-    image_local->pixel_format = SAIL_PIXEL_FORMAT_BPP96;
+    image_local->pixel_format = SAIL_PIXEL_FORMAT_BPP96_RGB_FLOAT;
 
     image_local->bytes_per_line = sail_bytes_per_line(image_local->width, image_local->pixel_format);
 
@@ -301,7 +301,7 @@ SAIL_EXPORT sail_status_t sail_codec_save_seek_next_frame_v8_hdr(void* state, co
     }
 
     /* HDR only supports BPP96 (32-bit float RGB). */
-    if (image->pixel_format != SAIL_PIXEL_FORMAT_BPP96)
+    if (image->pixel_format != SAIL_PIXEL_FORMAT_BPP96_RGB_FLOAT)
     {
         SAIL_LOG_ERROR("HDR: Only BPP96 (32-bit float RGB) pixel format is supported for writing");
         SAIL_LOG_AND_RETURN(SAIL_ERROR_UNSUPPORTED_PIXEL_FORMAT);
@@ -336,7 +336,7 @@ SAIL_EXPORT sail_status_t sail_codec_save_frame_v8_hdr(void* state, const struct
     struct hdr_codec_state* hdr_codec_state = state;
 
     /* HDR only supports BPP96 (32-bit float RGB). */
-    if (image->pixel_format != SAIL_PIXEL_FORMAT_BPP96)
+    if (image->pixel_format != SAIL_PIXEL_FORMAT_BPP96_RGB_FLOAT)
     {
         SAIL_LOG_ERROR("HDR: Only BPP96 (32-bit float RGB) pixel format is supported for writing");
         SAIL_LOG_AND_RETURN(SAIL_ERROR_UNSUPPORTED_PIXEL_FORMAT);

--- a/src/sail-codecs/hdr/hdr.codec.info.in
+++ b/src/sail-codecs/hdr/hdr.codec.info.in
@@ -16,7 +16,7 @@ tuning=
 
 [save-features]
 features=STATIC;META-DATA
-pixel-formats=BPP96
+pixel-formats=BPP96-RGB-FLOAT
 compressions=RLE
 default-compression=RLE
 compression-level-min=0


### PR DESCRIPTION
Since the HDR loader already specifies in its comments that the pixel format is RGB & float and converts the RGBE data as such, the pixel format enum should reflect this instead of using the "unknown pixel representation" BPP96 format.

---

I was using SAIL to load images and convert them to 4-channel formats for use in Vulkan (which generally has no 3-channel pixel formats). The BPP96 format didn't work with `sail_convert_image`, which is how I stumbled on this. Other than this issue, this library has been super nice to work with, thanks!